### PR TITLE
Fixed typo in RISCYPacker.vcxproj

### DIFF
--- a/RISCYPacker/RISCYPacker.vcxproj
+++ b/RISCYPacker/RISCYPacker.vcxproj
@@ -95,7 +95,7 @@
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
-      <AdditionalLibraryDirectoriesboost_1_65_1\boost_1_65_1\stage\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>boost_1_65_1\boost_1_65_1\stage\lib;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <AdditionalDependencies>Shlwapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>


### PR DESCRIPTION
Visual Studio was unable to load project until fix.